### PR TITLE
perf: optimize flashlight load

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,8 @@ title: Blog
     </div>
   </div>
 
+  <div class="lazy-load"></div>
+
   {% assign published_posts = site.posts | where_exp: "post", "post.draft != true" %}
   {% assign posts_by_year = published_posts | group_by_exp: "post", "post.date | date: '%Y'"  %}
   {% for year in posts_by_year %}

--- a/style.css
+++ b/style.css
@@ -116,6 +116,11 @@ sub { top: .5ex; }
   .hoverable:hover { object-position: center bottom; }
 }
 
+.lazy-load::after {
+  content: '';
+  background-image: url(/i/flashlight.png);
+}
+
 .dark_mode { align-self: center; width: 50px; height: 24px; border-radius: 12px; background-image: url("/i/dark_mode.png"); background-size: 76px 24px; background-position: -26px 0; transition: 100ms; }
 body.dark { background-color: #000; background-image: url(/i/flashlight.png); background-repeat: no-repeat; background-size: 500px 500px; }
 body.dark .dark_mode { background-position: 0 0; }


### PR DESCRIPTION
When you switch dark for the first time, the image will not appear immediately because `flashlight.png` takes time to load.

Adding this class will start to load `flashlight.png` as soon as you enter it without affecting the main interface.