### PR TITLE
typo: Change `Let’t` to `Let’s`.

### DIFF
--- a/_posts/2021-03-29-font-size.md
+++ b/_posts/2021-03-29-font-size.md
@@ -7,7 +7,7 @@ summary: "What happens when you set fontSize: 32 in your favorite editor"
 
 What happens when you set `"font_size": 32` in your favorite editor? I would’ve told you anyway, but I’m glad that you asked.
 
-Let’t try to guess. I am using Sublime Text 4 on macOS:
+Let’s try to guess. I am using Sublime Text 4 on macOS:
 
 <figure><img src="sublime.png"></figure>
 


### PR DESCRIPTION
# Summary

This patch fixes the typo in `Let't`.