### PR TITLE
Add LG 27GN950-B for MacBook Air M1 2020

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -68,6 +68,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>ASUS PG27UQ</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GN950-B</span></div>
+
 # How to contribute?
 
 If you have a combination of 4k monitor with 120+ Hz refresh rate and a Mac that’s not listed here, please [open a PR](https://github.com/tonsky/tonsky.github.io) (don’t worry about graphics/icons, I can add those myself).


### PR DESCRIPTION
<img width="698" alt="Screenshot 2021-06-28 at 12 40 25" src="https://user-images.githubusercontent.com/9990627/123616957-742ac080-d80f-11eb-8598-7d412baf6c50.png">
<img width="1015" alt="Screenshot 2021-06-28 at 12 40 49" src="https://user-images.githubusercontent.com/9990627/123616984-79880b00-d80f-11eb-91a8-232dedaeb5bf.png">

This monitor also works with the 16" MacBook Pro, although I don’t have the screenshots at the moment.