### PR TITLE
MacBook Pro (16-inch, 2019) and Acer NITRO V3

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -52,6 +52,10 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>ASUS XG27UQ</span></div>
 
+## <img src="mbp_16_2020.png" height=32> <span>MacBook Pro (16-inch, 2019) w/ Radeon Pro 5300M</span>
+
+<div class="row"><img src="works.png" height=64> <span>Acer NITRO V3 (XV273K Pbmiipphzx)</span></div>
+
 ## <img src="mbp_16_2020.png" height=32> <span>Macbook Pro (16-inch, 2019) w/ Radeon 5500M</span>
 
 <div class="row"><img src="works.png" height=64> <span>ASUS XG27UQ</span></div>


### PR DESCRIPTION
This PR adds compatibility information for MacBook Pro (16-inch, 2019) w/ Radeon Pro 5300M and Acer NITRO XV3 (XV273K Pbmiipphzx).
![image](https://user-images.githubusercontent.com/2316604/123839647-35a20e00-d8c2-11eb-8cfb-02e5bbfa86a2.png)
![image](https://user-images.githubusercontent.com/2316604/123839666-3b97ef00-d8c2-11eb-8135-de3633469b92.png)