### PR TITLE
New LG monitor 34GN850-B

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -50,6 +50,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GN950-B</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>LG UltraGear 34GN850-B</span></div>
+
 <div class="row"><img src="doesnt_work.png" height=64> <span>ASUS XG27UQ</span></div>
 
 ## <img src="mbp_16_2020.png" height=32> <span>MacBook Pro (16-inch, 2019) w/ Radeon Pro 5300M</span>


### PR DESCRIPTION
34GN850-B work fine with 144 on Mac if use displayport -> usb c
![image](https://user-images.githubusercontent.com/2185721/124377115-00773080-dcb3-11eb-8dbb-e266699bbcac.png)
