### PR TITLE
Add LG C1 65

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -57,6 +57,7 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 ## <img src="mbp_16_2020.png" height=32> <span>MacBook Pro (16-inch, 2019) w/ Radeon Pro 5300M</span>
 
 <div class="row"><img src="works.png" height=64> <span>Acer NITRO XV3 (XV273K Pbmiipphzx)</span></div>
+<div class="row"><img src="doesnt_work.png" height=64> <span>2021 LG C1 65-inch OLED</span></div>
 
 ## <img src="mbp_16_2020.png" height=32> <span>Macbook Pro (16-inch, 2019) w/ Radeon 5500M</span>
 
@@ -64,6 +65,7 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>Acer Predator XB3 (XB273K GP)</span></div>
 
+<div class="row"><img src="doesnt_work.png" height=64> <span>2021 LG C1 65-inch OLED</span></div>
 <div class="row"><img src="doesnt_work.png" height=64> <span>2021 LG C1 48-inch OLED</span></div>
 
 ## <img src="imac_2020.png" height=44> <span>iMac (2020) w/ Radeon 5700XT</span>


### PR DESCRIPTION
I'm guessing that both the 48- and 65-inch C1s use the same chips underneath, but I was able to test against both the 5300M and 5500M video cards.

I also tried in both open, and clamshell modes. No change in symptoms/capabilities.

If you reduce the resolution on the 2019 16-inch to 1440p you get 120hz on MacOS against both the 5300M and 5500M cards.

I wonder if an external graphics card would do it. Don't have one to test.