### PR TITLE
monitors-mac: Add Gigabyte M28U

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -101,6 +101,10 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GP950-B (4k @ 144Hz)</span></div>
 
+## <img src="mbp_14_2021.png" height=32> <span>MacBook Pro 14" (M1 Max, 2021)</span>
+
+<div class="row"><img src="works.png" height=64> <span>Gigabyte M28U (4k @ 144Hz)</span></div>
+
 # How to contribute?
 
 If you have a combination of 4k monitor with 120+ Hz refresh rate and a Mac that’s not listed here, please [open a PR](https://github.com/tonsky/tonsky.github.io) (don’t worry about graphics/icons, I can add those myself).


### PR DESCRIPTION
The Gigabyte M28U runs at 144Hz over USB-C on both the MBP and the monitor.

<img width="886" alt="Screen Shot" src="https://user-images.githubusercontent.com/1146876/141664813-544d172e-65c9-4112-b357-fd4306d486a1.png">

Not entirely sure what's up with the reported resolution of the monitor, since it's definitely 4k. Might be due to the scaling settings that I'm currently using.