### PR TITLE
Add MacBook Pro (16-inch, 2019) w/ Radeon Pro 5500M  / Acer NITRO XV3

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -36,11 +36,11 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>Acer NITRO XV3 (XV273K Pbmiipphzx)</span></div>
 
-## <img src="air_2018.png" height=32> <span>MacBook Air (Retina, 13", 2018)</span>
+## <img src="air_2018.png" height=32> <span>MacBook Air (Retina, 13-inch, 2018)</span>
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>Acer NITRO XV3 (XV273K Pbmiipphzx)</span></div>
 
-## <img src="mbp_13_2019.png" height=32> <span>MacBook Pro (13 inch, 2019)</span>
+## <img src="mbp_13_2019.png" height=32> <span>MacBook Pro (13-inch, 2019)</span>
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>Acer NITRO XV3 (XV273K Pbmiipphzx)</span></div>
 
@@ -48,11 +48,11 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>Acer NITRO XV3 (XV273K Pbmiipphzx)</span></div>
 
+<div class="row"><img src="doesnt_work.png" height=64> <span>ASUS ROG Strix XG27UQ</span></div>
+
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GN950-B</span></div>
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 34GN850-B</span> (1440p @ 144Hz)</div>
-
-<div class="row"><img src="doesnt_work.png" height=64> <span>ASUS XG27UQ</span></div>
 
 ## <img src="mbp_16_2020.png" height=32> <span>MacBook Pro (16-inch, 2019) w/ Radeon Pro 5300M</span>
 
@@ -60,18 +60,23 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>2021 LG C1 65-inch OLED</span></div>
 
-## <img src="mbp_16_2020.png" height=32> <span>Macbook Pro (16-inch, 2019) w/ Radeon 5500M</span>
+## <img src="mbp_16_2020.png" height=32> <span>MacBook Pro (16-inch, 2019) w/ Radeon Pro 5500M</span>
 
-<div class="row"><img src="works.png" height=64> <span>ASUS XG27UQ</span></div>
+<div class="row"><img src="works.png" height=64> <span>Acer NITRO XV3 (XV273K Pbmiipphzx)</span></div>
 
 <div class="row"><img src="works.png" height=64> <span>Acer Predator XB3 (XB273K GP)</span></div>
+
+<div class="row"><img src="works.png" height=64> <span>ASUS ROG Strix XG27UQ</span></div>
+
 <div class="row"><img src="works.png" height=64> <span>Gigabyte M28U</span></div>
+
 <div class="row"><img src="doesnt_work.png" height=64> <span>2021 LG C1 65-inch OLED</span></div>
+
 <div class="row"><img src="doesnt_work.png" height=64> <span>2021 LG C1 48-inch OLED</span></div>
 
-## <img src="imac_2020.png" height=44> <span>iMac (2020) w/ Radeon 5700XT</span>
+## <img src="imac_2020.png" height=44> <span>iMac (2020) w/ Radeon Pro 5700 XT</span>
 
-<div class="row"><img src="works.png" height=64> <span>Asus PA32UCG</span></div>
+<div class="row"><img src="works.png" height=64> <span>ASUS ProArt Display PA32UCG</span></div>
 
 ## <img src="mini_2018.png" height=32> <span>Mac mini (M1, 2020)</span>
 
@@ -90,7 +95,7 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>Acer NITRO XV3 (XV273K Pbmiipphzx) only on Monterey</span></div>
 
-<div class="row"><img src="works.png" height=64> <span>ASUS PG27UQ</span></div>
+<div class="row"><img src="works.png" height=64> <span>ASUS ROG Swift PG27UQ</span></div>
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GN950-B</span></div>
 
@@ -100,11 +105,11 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GP950-B (4k @ 144Hz)</span></div>
 
-## <img src="mbp_14_2021.png" height=32> <span>MacBook Pro 14" (M1 Pro, 2021)</span>
+## <img src="mbp_14_2021.png" height=32> <span>MacBook Pro (M1 Pro, 14-inch, 2021)</span>
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GP950-B (4k @ 144Hz)</span></div>
 
-## <img src="mbp_14_2021.png" height=32> <span>MacBook Pro 14" (M1 Max, 2021)</span>
+## <img src="mbp_14_2021.png" height=32> <span>MacBook Pro (M1 Max, 14-inch, 2021)</span>
 
 <div class="row"><img src="works.png" height=64> <span>Gigabyte M28U (4k @ 144Hz)</span></div>
 


### PR DESCRIPTION
Also:
 - Fixed the names of some Macs following the "Name (Screen-Size, Year) w/ Graphics-Card" pattern
 - Fixed some monitor names following the "Brand Marketing-Name Model" pattern
 - Ordered monitor names alphabetically
 - Fixed names of some graphics cards, sourcing the official Apple specs