### PR TITLE
Add Gigabyte M28U for MBP 15 2018

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -54,6 +54,10 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 34GN850-B</span> (1440p @ 144Hz)</div>
 
+## <img src="mbp_15_2019.png" height=32> <span>MacBook Pro (15-inch, 2018) w/ Radeon Pro 560X</span>
+
+<div class="row"><img src="doesnt_work.png" height=64> <span>Gigabyte M28U</span></div>
+
 ## <img src="mbp_16_2020.png" height=32> <span>MacBook Pro (16-inch, 2019) w/ Radeon Pro 5300M</span>
 
 <div class="row"><img src="works.png" height=64> <span>Acer NITRO XV3 (XV273K Pbmiipphzx)</span></div>


### PR DESCRIPTION
Unfortunately, I failed to make the monitor work at 4K@144Hz using c2c cable and c2DP cable. I found that the graphics card can only support DP1.2 protocol in Windows. I don't know if Apple has made a restriction. Because MBP 15 2018 and MBP 15 2019 are exactly the same on the graphics card and the Thunderbolt 3 main control chip. If you can successfully use 4K@144Hz on MBP 15 2018, please let me know how to use it, or if anyone knows why it can’t be used, please let me know.