### PR TITLE
Added Mac Pro (2019) with Acer X27

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -54,6 +54,10 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 34GN850-B</span> (1440p @ 144Hz)</div>
 
+## <img src="mp_2019.png" height=32> <span>Mac Pro (2019) w/ Radeon Pro 580X</span>
+
+<div class="row"><img src="works.png" height=64> <span>Acer X27</span></div>
+
 ## <img src="mbp_15_2019.png" height=32> <span>MacBook Pro (15-inch, 2018) w/ Radeon Pro 560X</span>
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>Gigabyte M28U</span></div>


### PR DESCRIPTION
I've been running this setup for over a year on a KVM. It only works without scaling, but I don't know if any mac hardware works with scaling and 120hz. When I turn scaling on the display flickers between being off and displaying a black screen.

He's some screenshots:

<img width="698" alt="Screen Shot 2021-12-11 at 12 38 29 PM" src="https://user-images.githubusercontent.com/4692/145686504-3c94be54-0883-471a-b22e-36eb0646601d.png">

<img width="1015" alt="Screen Shot 2021-12-11 at 12 39 18 PM" src="https://user-images.githubusercontent.com/4692/145686501-461419e6-a1a7-4868-9943-ca43cf6fbbf2.png">

