### PR TITLE
Help the Safari Reader mode algorithm

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,7 +13,7 @@ layout: default
 </ul>
 
 
-<div class="post">
+<article class="post">
   <h1 class="title">{{ page.title }}</h1>
 
   <p>{{ page.permalink }}</p>
@@ -64,4 +64,4 @@ layout: default
   </div>
   {% endif %}
 
-</div>
+</article>


### PR DESCRIPTION
Current behaviour:
Reader mode is not active for the https://tonsky.me/blog/disenchantment/ post (Safari desktop, Safari iOs).

Expected behaviour:
Reader mode is active for the https://tonsky.me/blog/disenchantment/ post

Explanation of the issue:
Safari Reader mode algorithm may be confused with UI-ish elements like translations list. Making layout more semantic usually solves the issue.

Proposed changes:
- Replace post wrapper `div` tag with the `article` tag. This will help the Safari Reader mode algorithm to discover post content.