### PR TITLE
Fix: Add a closing div tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,6 +49,8 @@
 
 <div class="preload"></div>
 
+</div>
+
 <script>
   function updateFlashlight(e) {
     var style = document.body.style;


### PR DESCRIPTION
I dare to propose a tiny fix to the website. `div` tags are not self-closing and must be accompanied by a closing `</div>` tag.

I don't see any visible issues with this, browsers are smart enough to handle it. But it could potentially help robots better understand the markup of a site. For example, Safari Reader mode (see related PR https://github.com/tonsky/tonsky.github.io/pull/46). So don't take this PR as a stupid nag.