### PR TITLE
Add MacBook Pro (M1 Max, 16-inch, 2021) and LG UltraGear 27GP950-B

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -130,6 +130,10 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>Gigabyte M28U (4k @ 144Hz)</span></div>
 
+## <img src="mbp_16_2021.png" height=32> <span>MacBook Pro (M1 Max, 16-inch, 2021)</span>
+
+<div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GP950-B (4k @ 144Hz)</span></div>
+
 # How to contribute?
 
 If you have a combination of 4k monitor with 120+ Hz refresh rate and a Mac that’s not listed here, please [open a PR](https://github.com/tonsky/tonsky.github.io) (don’t worry about graphics/icons, I can add those myself).


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1711757/149450743-2c7ddc5a-428c-436b-9475-4a79bd579e96.png)

![image](https://user-images.githubusercontent.com/1711757/149450766-70e719a8-272b-4647-8f94-23348ae2696b.png)

Connected via USB-C to DisplayPort cable