### PR TITLE
Add Macbook Pro 16" M1 Pro and Macbook Pro 15" 2018 with Gigabyte M32U

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -131,6 +131,10 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>Gigabyte M28U (4k @ 144Hz)</span></div>
 
+## <img src="mbp_16_2021.png" height=32> <span>MacBook Pro (M1 Pro, 16-inch, 2021)</span>
+
+<div class="row"><img src="works.png" height=64> <span>Gigabyte M32U (4k @ 144Hz)</span></div>
+
 ## <img src="mbp_16_2021.png" height=32> <span>MacBook Pro (M1 Max, 16-inch, 2021)</span>
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GP950-B (4k @ 144Hz)</span></div>

--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -62,6 +62,7 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 ## <img src="mbp_15_2019.png" height=32> <span>MacBook Pro (15-inch, 2018) w/ Radeon Pro 560X</span>
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>Gigabyte M28U</span></div>
+<div class="row"><img src="works.png" height=64> <span>Gigabyte M32U (4k @ 120Hz)</span></div>
 
 ## <img src="mbp_16_2020.png" height=32> <span>MacBook Pro (16-inch, 2019) w/ Radeon Pro 5300M</span>
 


### PR DESCRIPTION
This screen work for Macbook Pro 16" with M1 Pro chip. I'm using USB-C to DisplayPort 1.4 cable:

<img width="698" alt="Screen Shot 2022-02-02 at 9 28 14 am" src="https://user-images.githubusercontent.com/128535/152069167-88f87b7b-be43-4ad7-81bc-28f205e1c540.png">
<img width="1015" alt="Screen Shot 2022-02-02 at 9 28 24 am" src="https://user-images.githubusercontent.com/128535/152069184-2c4180f1-d44e-46ef-aa25-8d867e6f5946.png">
<img width="780" alt="Screen Shot 2022-02-02 at 9 33 00 am" src="https://user-images.githubusercontent.com/128535/152069192-97944522-7a58-4a64-be8e-575607d989b6.png">

With my old Macbook Pro 15" 2018, the refresh rate is only 120Hz with USB-C to DisplayPort 1.4 cable:
<img width="698" alt="Screen Shot 2022-02-02 at 9 36 22 am" src="https://user-images.githubusercontent.com/128535/152069837-71db413a-32e4-4bd3-9f69-b1acf16fa9e1.png">
<img width="1015" alt="Screen Shot 2022-02-02 at 9 36 37 am" src="https://user-images.githubusercontent.com/128535/152069854-3d7feb91-7d7e-46b9-9e09-a626e73a7e04.png">
<img width="780" alt="Screen Shot 2022-02-02 at 9 36 14 am" src="https://user-images.githubusercontent.com/128535/152069891-17e67a80-ceef-4fd6-9fc7-6dc4ba6aa9a0.png">

