### PR TITLE
Update 2021-02-24-monitors-mac.md to add Dell Monitor to Macbook Pro 13" M1 Chip

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -120,6 +120,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GP950-B (4k @ 144Hz)</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>Dell S3422DWG (4k @ 144Hz)</span></div>
+
 ## <img src="mbp_14_2021.png" height=32> <span>MacBook Pro (M1 Pro, 14-inch, 2021)</span>
 
 <div class="row"><img src="works.png" height=64> <span>Acer Nitro XV3 (XV273K Pbmiipphzx)</span></div>


### PR DESCRIPTION
Added Dell S3422DWG Curved 34" monitor.