### PR TITLE
Add Acer Predator XB3 to the 2021 M1 Pro 14-inch model

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -128,6 +128,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GP950-B (4k @ 144Hz)</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>Acer Predator XB3 (XB273K GP) (4k @ 120Hz)</span></div>
+
 ## <img src="mbp_14_2021.png" height=32> <span>MacBook Pro (M1 Max, 14-inch, 2021)</span>
 
 <div class="row"><img src="works.png" height=64> <span>Gigabyte M28U (4k @ 144Hz)</span></div>


### PR DESCRIPTION
I was able to achieve:
- 4k @120Hz with a good DP 1.4 <-> USB-C cable
- 4k @60Hz with a good HDMI 2.0 cable.