### PR TITLE
Added XB283K

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -134,6 +134,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>Acer Predator XB3 (XB273K GP) (4k @ 120Hz)</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>Acer Predator XB283K KVbmiipruzx (4k @ 144Hz)</span></div>
+
 ## <img src="mbp_14_2021.png" height=32> <span>MacBook Pro (M1 Max, 14-inch, 2021)</span>
 
 <div class="row"><img src="works.png" height=64> <span>Gigabyte M28U (4k @ 144Hz)</span></div>


### PR DESCRIPTION
I recently bought the [XB283K](https://www.amazon.com/Acer-Predator-KVbmiipruzx-Agile-Splendor-Compatible/dp/B09HN33HRD) to use with my M1 Pro  14" MBP and it's working great!

Screenshots requested:
<img width="698" alt="CleanShot 2022-03-01 at 22 00 20" src="https://user-images.githubusercontent.com/2278221/156294622-242b4cd4-daad-4c94-b6c9-145788ca1a6c.png">
<img width="1015" alt="CleanShot 2022-03-01 at 22 00 50" src="https://user-images.githubusercontent.com/2278221/156294623-7f5f36d3-b0a7-48ca-89c7-4b23d1552f8d.png">
