### PR TITLE
update XB283K for MacBook Pro 13-inch 2020 Intel model.

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -86,6 +86,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>Gigabyte M32U</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>Acer Predator XB283K KV</span></div>
+
 ## <img src="imac_2020.png" height=44> <span>iMac (2020) w/ Radeon Pro 5700 XT</span>
 
 <div class="row"><img src="works.png" height=64> <span>ASUS ProArt Display PA32UCG</span></div>


### PR DESCRIPTION
Hey I recently bought a Type-C2DP1.4 Cable and it's works very well with my MacBook Pro 2020 13-inch with Acer Predator XB283K KV. Everything works fine.
![IMG_2575](https://user-images.githubusercontent.com/40574192/159890711-99ac20a9-e615-45a6-9c6b-3e7b3a1ae141.JPG)
![2022-03-24 17 56 29](https://user-images.githubusercontent.com/40574192/159890762-9ac3d1f8-bee1-4f08-b476-ec5a267ac8e5.jpg)

