### PR TITLE
Update 2021-02-24-monitors-mac.md

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -142,6 +142,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 ## <img src="mbp_16_2021.png" height=32> <span>MacBook Pro (M1 Pro, 16-inch, 2021)</span>
 
+<div class="row"><img src="works.png" height=64> <span>Gigabyte M28U</span></div>
+
 <div class="row"><img src="works.png" height=64> <span>Gigabyte M32U (4k @ 144Hz)</span></div>
 
 <div class="row"><img src="works.png" height=64> <span>Acer Nitro XV2 (XV282K KVbmiipruzx) (4k @ 144Hz)</span></div>


### PR DESCRIPTION
16" M1 Pro works perfectly with M28U