### PR TITLE
Gigabye M28U works with MacBook Air (M1, 2020)

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -120,6 +120,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>LG CX 4K OLED TV (55-inch, 2020)</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>Gigabyte M28U</span></div>
+
 ## <img src="mbp_13_2020.png" height=32> <span>MacBook Pro (M1, 2020)</span>
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GP950-B (4k @ 144Hz)</span></div>


### PR DESCRIPTION
Thanks for maintaining this list. It was helpful. Here's my contribution.

<img width="698" alt="Screen Shot 2022-04-05 at 09 27 37" src="https://user-images.githubusercontent.com/162998/163067653-efcae623-9ca6-4635-873b-cabb55d25a1d.png">

<img width="1015" alt="Screen Shot 2022-04-05 at 09 28 21" src="https://user-images.githubusercontent.com/162998/163067658-abee2b78-e560-4831-b048-df1d741e5936.png">
