### PR TITLE
Dell G3223Q doesn't work with 16-inch MBP 2019

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -82,6 +82,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>LG C1 4K OLED TV (48-inch, 2021)</span></div>
 
+<div class="row"><img src="doesnt_work.png" height=64> <span>Dell G3223Q</span></div>
+
 ## <img src="mbp_13_2020.png" height=32> <span>MacBook Pro (Intel, 13-inch, 2020) </span>
 
 <div class="row"><img src="works.png" height=64> <span>Gigabyte M32U</span></div>


### PR DESCRIPTION

![CleanShot 2022-04-19 at 09 54 46@2x](https://user-images.githubusercontent.com/13172514/163896268-8fa31f68-567f-41c7-911e-de51cdf1cecb.png)
![CleanShot 2022-04-19 at 09 54 58@2x](https://user-images.githubusercontent.com/13172514/163896270-38fa4d9e-6920-4cdb-801d-b25fa1b9dd51.png)

Using USB-C to Display Port cable (the cable supports 4K 144hz on my M1 Macbook Air, so it's all good).

