### PR TITLE
Add negative result for MacBook Pro (16-inch, 2019) w/ Radeon Pro 5500M

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -78,6 +78,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>Gigabyte M28U</span></div>
 
+<div class="row"><img src="doesnt_work.png" height=64> <span>LG CX 4K OLED TV (55-inch, 2020)</span></div>
+
 <div class="row"><img src="doesnt_work.png" height=64> <span>LG C1 4K OLED TV (65-inch, 2021)</span></div>
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>LG C1 4K OLED TV (48-inch, 2021)</span></div>


### PR DESCRIPTION
Add negative result for MacBook Pro (16-inch, 2019) w/ Radeon Pro 5500M and LG CX 4K OLED TV (55-inch, 2020).

Bummer.

![818ECFFD-9B96-4051-BB2C-9E8147D39F5C](https://user-images.githubusercontent.com/1878152/170090787-a8752c33-5ba5-4456-aa69-d1332df668d4.jpeg)

![8331BCC9-0B4B-4B3D-9074-57320569CA70](https://user-images.githubusercontent.com/1878152/170090791-a02c0d03-3279-4c8b-8312-eed3aca363e4.jpeg)

