### PR TITLE
Added Multiple Compatible Displays & Macs.

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -120,6 +120,10 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>ASUS ROG Swift PG27UQ</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>Asus ROG Swift PG32UQ (4k @ 144Hz)</span></div>
+
+<div class="row"><img src="works.png" height=64> <span>Gigabyte M32U (4k @ 144Hz)</span></div>
+
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GN950-B</span></div>
 
 <div class="row"><img src="doesnt_work.png" height=64> <span>LG CX 4K OLED TV (55-inch, 2020)</span></div>
@@ -160,9 +164,15 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GP950-B (4k @ 144Hz)</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>Gigabyte M32U (4k @ 144Hz)</span></div>
+
+<div class="row"><img src="works.png" height=64> <span>Asus ROG Swift PG32UQ (4k @ 144Hz)</span></div>
+
 ## <img src="studio_2022.png" height=32> <span>Mac Studio (M1 Max, 2022)</span>
 
 <div class="row"><img src="works.png" height=64> <span>Acer Nitro XV2 (XV282K KVbmiipruzx) (4k @ 144Hz)</span></div>
+
+<div class="row"><img src="works.png" height=64> <span>Asus ROG Swift PG32UQ (4k @ 144Hz)</span></div>
 
 ## <img src="studio_2022.png" height=32> <span>Mac Studio (M1 Ultra, 2022)</span>
 


### PR DESCRIPTION
MacBook Air (M1, 2020)
- Asus ROG Swift PG32UQ
- Gigabyte M32U
![Screen Shot 2022-08-07 at 7 19 59 AM](https://user-images.githubusercontent.com/7291498/183269127-a1ade501-4182-49db-883c-c4732decbf26.png)
![Screen Shot 2022-08-07 at 7 20 09 AM](https://user-images.githubusercontent.com/7291498/183269133-c6655e29-9c73-4e03-a266-ea5f7de9e9a8.png)
![Screen Shot 2022-08-07 at 7 14 00 AM](https://user-images.githubusercontent.com/7291498/183269137-5d6410df-aa6e-4556-904a-583effcbee60.png)

MacBook Pro (M1 Max, 16-inch, 2021)
- Asus ROG Swift PG32UQ
- Gigabyte M32U
![CleanShot 2022-08-07 at 07 25 59@2x](https://user-images.githubusercontent.com/7291498/183269104-784f945b-c80f-46cf-8310-eff9e18abe06.png)
![CleanShot 2022-08-07 at 07 15 17](https://user-images.githubusercontent.com/7291498/183269111-877f8d62-f7d2-40c4-b4a2-86d6e54f9f4f.png)
<img width="1092" alt="CleanShot 2022-08-07 at 07 26 25@2x" src="https://user-images.githubusercontent.com/7291498/183269118-fe4423ed-db9b-43c5-88e8-1c7a08da151a.png">

Mac Studio (M1 Max, 2022)
- Asus ROG Swift PG32UQ
![Screen Shot 2022-08-07 at 7 08 56 AM](https://user-images.githubusercontent.com/7291498/183269150-a5131288-df65-4c33-9a87-fad1d7d93f3c.png)
<img width="834" alt="Screen Shot 2022-08-07 at 7 09 37 AM" src="https://user-images.githubusercontent.com/7291498/183269155-63a7648f-63b9-48d1-9446-a569f91824eb.png">