### PR TITLE
Samsung G70A 28" works with MBP14" M1 Max & MBA M1

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -132,6 +132,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>Dell G3223Q</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>Samsung G70A 28" (4K @ 144 Hz)</span></div>
+
 ## <img src="mbp_13_2020.png" height=32> <span>MacBook Pro (M1, 2020)</span>
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GP950-B (4k @ 144Hz)</span></div>
@@ -153,6 +155,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 ## <img src="mbp_14_2021.png" height=32> <span>MacBook Pro (M1 Max, 14-inch, 2021)</span>
 
 <div class="row"><img src="works.png" height=64> <span>Gigabyte M28U (4k @ 144Hz)</span></div>
+
+<div class="row"><img src="works.png" height=64> <span>Samsung G70A 28" (4K @ 144 Hz)</span></div>
 
 ## <img src="mbp_16_2021.png" height=32> <span>MacBook Pro (M1 Pro, 16-inch, 2021)</span>
 


### PR DESCRIPTION
4K @ 144 Hz using CableMatters USB-C - DP cable.

NB: Did not work on macOS 12.5.1, only DP 1.2 would function.


Pro:

![pro0](https://user-images.githubusercontent.com/69935098/200920686-19299ac7-e8c4-41d8-87d3-b76edc840ba0.png)
![pro1](https://user-images.githubusercontent.com/69935098/200920693-00088c10-c99f-47c3-9074-2f29a7064a48.png)


Air:

![air0](https://user-images.githubusercontent.com/69935098/200920716-3b856d61-2717-46f4-94ba-5c98cdf4dd7e.png)
![air1](https://user-images.githubusercontent.com/69935098/200920723-bb5f5976-e5af-4216-8995-364a28c2dc04.png)
