### PR TITLE
Add Odyssey G7 for MacBook Pro

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -168,6 +168,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>Acer Nitro XV2 (XV282K KVbmiipruzx) (4k @ 144Hz)</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>Samsung Odyssey G7 S28AG70 (4k @ 144Hz)</span></div>
+
 ## <img src="mbp_16_2021.png" height=32> <span>MacBook Pro (M1 Max, 16-inch, 2021)</span>
 
 <div class="row"><img src="works.png" height=64> <span>LG UltraGear 27GP950-B (4k @ 144Hz)</span></div>


### PR DESCRIPTION
Add Samsung Odyssey G7 S28AG70 for a MacBook Pro (M1 Pro, 16-inch, 2021)