### PR TITLE
Add Odyssey Neo G7 for a MacBook

### DIFF
--- a/_posts/2021-02-24-monitors-mac.md
+++ b/_posts/2021-02-24-monitors-mac.md
@@ -178,6 +178,8 @@ This list is about supporting full 4k resolution (3840×2160) at 120Hz only! <sp
 
 <div class="row"><img src="works.png" height=64> <span>Asus ROG Swift PG32UQ (4k @ 144Hz)</span></div>
 
+<div class="row"><img src="works.png" height=64> <span>Samsung Odyssey Neo G7 S32BG75 (4k @ 120Hz)</span></div>
+
 ## <img src="studio_2022.png" height=32> <span>Mac Studio (M1 Max, 2022)</span>
 
 <div class="row"><img src="works.png" height=64> <span>Acer Nitro XV2 (XV282K KVbmiipruzx) (4k @ 144Hz)</span></div>


### PR DESCRIPTION
Added the Samsung Odyssey Neo G7 (LS32BG75) for the 16 inch MacBook Pro M1 Max (2021). Works with 4k 120hz over DisplayPort.
![2023-02-02 at 8 17 59@2x](https://user-images.githubusercontent.com/64994269/216465473-ecc0bf88-7a79-469d-a1a7-0c4973c2006d.png)
![2023-02-02 at 8 18 31@2x](https://user-images.githubusercontent.com/64994269/216465480-bda17b0e-1835-4646-886c-5d67e9a9746c.png)
